### PR TITLE
Add Framedblocks compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,7 @@ dependencies {
 
     implementation "curse.maven:jade-324717:${jade_version}"
     implementation "curse.maven:fusion-connected-textures-854949:${fusion_version}"
+    implementation "curse.maven:framedblocks-441647:${framedblocks_version}"
 
     runtimeOnly "curse.maven:euphoria-patches-915902:7236770"
     runtimeOnly "curse.maven:sodium-394468:6382651"
@@ -109,16 +110,17 @@ dependencies {
 
 var generateModMetadata = tasks.register("generateModMetadata", ProcessResources) {
     var replaceProperties = [
-            minecraft_version      : minecraft_version,
-            minecraft_version_range: minecraft_version_range,
-            neo_version            : neo_version,
-            loader_version_range   : loader_version_range,
-            mod_id                 : mod_id,
-            mod_name               : mod_name,
-            mod_license            : mod_license,
-            mod_version            : mod_version,
-            mod_authors            : mod_authors,
-            mod_description        : mod_description
+            minecraft_version         : minecraft_version,
+            minecraft_version_range   : minecraft_version_range,
+            neo_version               : neo_version,
+            loader_version_range      : loader_version_range,
+            mod_id                    : mod_id,
+            mod_name                  : mod_name,
+            mod_license               : mod_license,
+            mod_version               : mod_version,
+            mod_authors               : mod_authors,
+            mod_description           : mod_description,
+            framedblocks_version_range: framedblocks_version_range
     ]
     inputs.properties replaceProperties
     expand replaceProperties

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,3 +29,5 @@ emi=1.1.22
 jei=19.25.1.332
 jade_version=6291517
 fusion_version=6453834
+framedblocks_version=7135071
+framedblocks_version_range=[10.5.1,11.0.0)

--- a/src/main/java/dev/satherov/crystalix/compat/framedblocks/CSFramedBlocksCompat.java
+++ b/src/main/java/dev/satherov/crystalix/compat/framedblocks/CSFramedBlocksCompat.java
@@ -1,0 +1,37 @@
+package dev.satherov.crystalix.compat.framedblocks;
+
+import dev.satherov.crystalix.Crystalix;
+
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.ModList;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+import xfacthd.framedblocks.api.camo.CamoContainerFactory;
+import xfacthd.framedblocks.api.util.FramedConstants;
+
+@Mod(value = Crystalix.MOD_ID)
+public final class CSFramedBlocksCompat {
+
+    public CSFramedBlocksCompat(IEventBus modBus) {
+        if (ModList.get().isLoaded("framedblocks")) {
+            Guarded.init(modBus);
+        }
+    }
+
+    static final class Guarded {
+
+        private static final DeferredRegister<CamoContainerFactory<?>> CAMO_FACTORIES = DeferredRegister.create(FramedConstants.CAMO_CONTAINER_FACTORY_REGISTRY_KEY, Crystalix.MOD_ID);
+
+        static final DeferredHolder<CamoContainerFactory<?>, CrystalixGlassCamoContainerFactory> FACTORY_CS_BLOCK = CAMO_FACTORIES.register(
+                "crystalix_glass", CrystalixGlassCamoContainerFactory::new
+        );
+
+        private static void init(IEventBus modBus) {
+            CAMO_FACTORIES.register(modBus);
+        }
+
+        private Guarded() { }
+    }
+}

--- a/src/main/java/dev/satherov/crystalix/compat/framedblocks/CrystalixGlassCamoContainer.java
+++ b/src/main/java/dev/satherov/crystalix/compat/framedblocks/CrystalixGlassCamoContainer.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.state.BlockState;
 
 import xfacthd.framedblocks.api.camo.block.AbstractBlockCamoContainer;
@@ -26,6 +27,11 @@ final class CrystalixGlassCamoContainer extends AbstractBlockCamoContainer<Cryst
 
     @Override
     public int getTintColor(ItemStack stack, int tintIdx) {
+        return tintColor;
+    }
+
+    @Override
+    public Integer getBeaconColorMultiplier(LevelReader level, BlockPos pos, BlockPos beaconPos) {
         return tintColor;
     }
 

--- a/src/main/java/dev/satherov/crystalix/compat/framedblocks/CrystalixGlassCamoContainer.java
+++ b/src/main/java/dev/satherov/crystalix/compat/framedblocks/CrystalixGlassCamoContainer.java
@@ -1,0 +1,53 @@
+package dev.satherov.crystalix.compat.framedblocks;
+
+import lombok.Getter;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.world.level.block.state.BlockState;
+
+import xfacthd.framedblocks.api.camo.block.AbstractBlockCamoContainer;
+import xfacthd.framedblocks.api.camo.block.AbstractBlockCamoContainerFactory;
+
+final class CrystalixGlassCamoContainer extends AbstractBlockCamoContainer<CrystalixGlassCamoContainer> {
+
+    private final @Getter int tintColor;
+
+    CrystalixGlassCamoContainer(BlockState state, int tintColor) {
+        super(state);
+        this.tintColor = tintColor;
+    }
+
+    @Override
+    public int getTintColor(BlockAndTintGetter level, BlockPos pos, int tintIdx) {
+        return tintColor;
+    }
+
+    @Override
+    public int getTintColor(ItemStack stack, int tintIdx) {
+        return tintColor;
+    }
+
+    @Override
+    public int hashCode() {
+        return content.hashCode() * 31 + Integer.hashCode(tintColor);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (!(obj instanceof CrystalixGlassCamoContainer other)) return false;
+        return content.equals(other.content) && tintColor == other.tintColor;
+    }
+
+    @Override
+    public String toString() {
+        return "CrystalixGlassCamoContainer{content=" + content + ",tintColor=" + Integer.toHexString(0xFF000000 | tintColor) + "}";
+    }
+
+    @Override
+    public AbstractBlockCamoContainerFactory<CrystalixGlassCamoContainer> getFactory() {
+        return CSFramedBlocksCompat.Guarded.FACTORY_CS_BLOCK.value();
+    }
+}

--- a/src/main/java/dev/satherov/crystalix/compat/framedblocks/CrystalixGlassCamoContainerFactory.java
+++ b/src/main/java/dev/satherov/crystalix/compat/framedblocks/CrystalixGlassCamoContainerFactory.java
@@ -1,0 +1,185 @@
+package dev.satherov.crystalix.compat.framedblocks;
+
+import dev.satherov.crystalix.common.block.CrystalixGlass;
+import dev.satherov.crystalix.common.item.CrystalixWand;
+import dev.satherov.crystalix.common.properties.CSProperties;
+import dev.satherov.crystalix.core.CSRegistry;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.EmptyBlockGetter;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+
+import xfacthd.framedblocks.api.camo.TriggerRegistrar;
+import xfacthd.framedblocks.api.camo.block.AbstractBlockCamoContainerFactory;
+import xfacthd.framedblocks.api.util.CamoMessageVerbosity;
+import xfacthd.framedblocks.api.util.ConfigView;
+import xfacthd.framedblocks.api.util.Utils;
+
+import org.jetbrains.annotations.Nullable;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+final class CrystalixGlassCamoContainerFactory extends AbstractBlockCamoContainerFactory<CrystalixGlassCamoContainer> {
+
+    private static final MapCodec<CrystalixGlassCamoContainer> CODEC = RecordCodecBuilder.mapCodec(inst -> inst.group(
+            BlockState.CODEC.fieldOf("state").forGetter(CrystalixGlassCamoContainer::getState),
+            Codec.INT.fieldOf("color").forGetter(CrystalixGlassCamoContainer::getTintColor)
+    ).apply(inst, CrystalixGlassCamoContainer::new));
+    private static final StreamCodec<RegistryFriendlyByteBuf, CrystalixGlassCamoContainer> STREAM_CODEC = StreamCodec.composite(
+            ByteBufCodecs.idMapper(Block.BLOCK_STATE_REGISTRY),
+            CrystalixGlassCamoContainer::getState,
+            ByteBufCodecs.INT,
+            CrystalixGlassCamoContainer::getTintColor,
+            CrystalixGlassCamoContainer::new
+    );
+    private static final int DEFAULT_TINT = 0xFFFFFF;
+
+    @Override
+    protected CrystalixGlassCamoContainer createContainer(BlockState camoState, Level level, BlockPos pos, Player player, ItemStack stack) {
+        return createContainer(camoState, CrystalixWand.find(player), DEFAULT_TINT);
+    }
+
+    private static CrystalixGlassCamoContainer createContainer(BlockState camoState, ItemStack wandStack, int tintColor) {
+        if (!wandStack.getOrDefault(CSRegistry.APPLY_COLORLESS, false)) {
+            tintColor = wandStack.getOrDefault(CSRegistry.COLOR, DEFAULT_TINT);
+        }
+        return new CrystalixGlassCamoContainer(camoState, tintColor);
+    }
+
+    @Override
+    @Nullable
+    protected BlockState getStateFromItemStack(Level level, BlockPos pos, Player player, ItemStack stack) {
+        if (stack.getItem() instanceof BlockItem item) {
+            return applyWandModifiers(item.getBlock().defaultBlockState(), CrystalixWand.find(player));
+        }
+        return null;
+    }
+
+    private static BlockState applyWandModifiers(BlockState state, ItemStack wand) {
+        if (!(state.getBlock() instanceof CrystalixGlass glass)) return state;
+
+        // Apply properties from wand and reset unsupported ones to their default values
+        BlockState newState = glass.fromStack(state, wand)
+                .setValue(CrystalixGlass.WATERLOGGABLE, false)
+                .setValue(CrystalixGlass.REDSTONE, false)
+                .setValue(CrystalixGlass.GHOST, CSProperties.Ghost.BLOCK_ALL);
+        CSProperties.Light light = newState.getValue(CrystalixGlass.LIGHT);
+        if (light != CSProperties.Light.NONE && light != CSProperties.Light.LIGHT) {
+            newState = newState.setValue(CrystalixGlass.LIGHT, CSProperties.Light.NONE);
+        }
+        return newState;
+    }
+
+    @Override
+    protected CrystalixGlassCamoContainer copyContainerWithState(CrystalixGlassCamoContainer container, BlockState newCamoState) {
+        return new CrystalixGlassCamoContainer(newCamoState, container.getTintColor());
+    }
+
+    @Override
+    protected ItemStack createItemStack(Level level, BlockPos pos, Player player, ItemStack stack, CrystalixGlassCamoContainer container) {
+        return dropCamo(container);
+    }
+
+    @Override
+    public ItemStack dropCamo(CrystalixGlassCamoContainer container) {
+        return new ItemStack(container.getState().getBlock());
+    }
+
+    @Override
+    public boolean canApplyInCraftingRecipe(ItemStack stack) {
+        if (stack.getItem() instanceof BlockItem item) {
+            return isValidBlock(item.getBlock().defaultBlockState(), EmptyBlockGetter.INSTANCE, BlockPos.ZERO, null);
+        }
+        return false;
+    }
+
+    @Override
+    public CrystalixGlassCamoContainer applyCamoInCraftingRecipe(ItemStack stack) {
+        if (stack.getItem() instanceof BlockItem item) {
+            BlockState state = item.getBlock().defaultBlockState();
+            if (isValidBlock(state, EmptyBlockGetter.INSTANCE, BlockPos.ZERO, null)) {
+                return new CrystalixGlassCamoContainer(state, DEFAULT_TINT);
+            }
+        }
+        throw new IllegalStateException("applyCamoInCraftingRecipe() called without canApplyInCraftingRecipe() check");
+    }
+
+    @Override
+    public ItemStack getCraftingRemainder(ItemStack stack) {
+        if (!ConfigView.Server.INSTANCE.shouldConsumeCamoItem()) {
+            return stack.copyWithCount(1);
+        }
+        return ItemStack.EMPTY;
+    }
+
+    @Override
+    public CrystalixGlassCamoContainer handleInteraction(Level level, BlockPos pos, Player player, CrystalixGlassCamoContainer camo, ItemStack stack, InteractionHand hand) {
+        if (stack.is(CSRegistry.WAND)) {
+            BlockState state = applyWandModifiers(camo.getState(), stack);
+            return createContainer(state, stack, camo.getTintColor());
+        }
+        return camo;
+    }
+
+    @Override
+    protected boolean isValidBlock(BlockState camoState, BlockGetter level, BlockPos pos, @Nullable Player player) {
+        if (!(camoState.getBlock() instanceof CrystalixGlass)) {
+            return false;
+        }
+        if (camoState.is(Utils.BLOCK_BLACKLIST)) {
+            displayValidationMessage(player, MSG_BLACKLISTED, CamoMessageVerbosity.DEFAULT);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean canTriviallyConvertToItemStack() {
+        return true;
+    }
+
+    @Override
+    protected void writeToNetwork(CompoundTag tag, CrystalixGlassCamoContainer container) {
+        tag.putInt("state", Block.getId(container.getState()));
+        tag.putInt("color", container.getTintColor());
+    }
+
+    @Override
+    protected CrystalixGlassCamoContainer readFromNetwork(CompoundTag tag) {
+        return new CrystalixGlassCamoContainer(Block.stateById(tag.getInt("state")), tag.getInt("color"));
+    }
+
+    @Override
+    public MapCodec<CrystalixGlassCamoContainer> codec() {
+        return CODEC;
+    }
+
+    @Override
+    public StreamCodec<RegistryFriendlyByteBuf, CrystalixGlassCamoContainer> streamCodec() {
+        return STREAM_CODEC;
+    }
+
+    @Override
+    public void registerTriggerItems(TriggerRegistrar registrar) {
+        CSRegistry.ENTRIES.values()
+                .stream()
+                .map(Holder::value)
+                .map(Block::asItem)
+                .forEach(registrar::registerApplicationItem);
+        registrar.registerRemovalItem(Utils.FRAMED_HAMMER.value());
+    }
+}

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -30,3 +30,10 @@ type = "required"
 versionRange = "${minecraft_version_range}"
 ordering = "NONE"
 side = "BOTH"
+
+[[dependencies.${ mod_id }]]
+modId = "framedblocks"
+type = "optional"
+versionRange = "${framedblocks_version_range}"
+ordering = "NONE"
+side = "BOTH"


### PR DESCRIPTION
This PR implements support for using Crystalix glass blocks as camos on framed blocks.

Property support:
- Invisibility: currently non-functional but could be made to work by providing a different (i.e. empty) block model for blocks marked invisible
- Transparent: works as expected
- Waterloggable: non-functional as it's not feasible to support
- Reinforced: non-functional as it's not feasible to support
- Shadeless: works as expected
- Redstone: non-functional as it's not feasible to support
- Conductor: non-functional as it's not feasible to support
- Ghost: non-functional as it's not feasible to support, though FramedBlocks has a similar system, albeit less configurable
- Light: only None and Light are supported, Fake Light and Dark are not feasible to support
- Color: works as expected

Wand behaviour:
- Can modify blocks during application when held in the off-hand
- Can modify blocks already applied as camo
- Batch application is non-functional
- Property copying currently doesn't work, though that could be made to work with a couple additional changes

The properties of the block applied as camo are currently not shown through FramedBlocks' Jade support, though I'm thinking about what an API for extending the data shown about a camo could look like.